### PR TITLE
Rpa sem whom

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+APP_ENV=local
+APP_HOST_IP=127.0.0.1
+
+# Logs dos robos no Loki/Grafana.
+# O Grafana consulta o Loki; os robos enviam para o endpoint /loki/api/v1/push.
+LOKI_URL=http://localhost:3100/loki/api/v1/push
+LOKI_APPLICATION=onerequest-rpa
+LOKI_PUBLIC_URL=http://127.0.0.1:3100
+LOKI_TIMEOUT_SECONDS=2
+LOG_LEVEL=INFO
+
+PUSHGATEWAY_URL=http://127.0.0.1:9091
+PUSHGATEWAY_TIMEOUT_SECONDS=2
+
+GRAFANA_PORT=3000
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=troque-esta-senha
+GRAFANA_REMOTE_URL=http://127.0.0.1:3000
+GRAFANA_REMOTE_USER=admin
+GRAFANA_REMOTE_PASSWORD=troque-esta-senha
+
+# Retentativas do robo de detalhamento.
+RPA_DETALHES_MAX_TENTATIVAS=3
+RPA_DETALHES_ESPERA_RETRY_SEGUNDOS=10
+RPA_DETALHE_GOTO_TIMEOUT_MS=90000
+RPA_DETALHE_SELECTOR_TIMEOUT_MS=30000
+RPA_DMI_BOTAO_TIMEOUT_MS=30000
+RPA_DMI_POPUP_TENTATIVAS=3
+
+TWOTASK_BATCH_CREATE_URL=https://flow.mdradvocacia.com/api/v1/tasks/batch-create
+TWOTASK_BATCH_API_KEY=troque-esta-chave

--- a/.env.example
+++ b/.env.example
@@ -27,5 +27,13 @@ RPA_DETALHE_SELECTOR_TIMEOUT_MS=30000
 RPA_DMI_BOTAO_TIMEOUT_MS=30000
 RPA_DMI_POPUP_TENTATIVAS=3
 
+# Integração OneLog (autenticação via cookies, substitui login direto no SSO)
+ONELOG_API_URL=http://api-onelog.mdradvocacia.com
+ONELOG_USERNAME=
+ONELOG_PASSWORD=
+ONELOG_REQUEST_TIMEOUT=15
+ONELOG_STATUS_ATTEMPTS=150
+ONELOG_STATUS_INTERVAL_SECONDS=2
+
 TWOTASK_BATCH_CREATE_URL=https://flow.mdradvocacia.com/api/v1/tasks/batch-create
 TWOTASK_BATCH_API_KEY=troque-esta-chave

--- a/RPA/coletaDadosNumeroSolicitacoes.py
+++ b/RPA/coletaDadosNumeroSolicitacoes.py
@@ -1,5 +1,6 @@
 import time
 import subprocess
+import tempfile
 from pathlib import Path
 from playwright.sync_api import sync_playwright, Page, Frame
 import json
@@ -23,6 +24,81 @@ install_print_logger("robo-coleta-numeros")
 # --- CONFIGURAÇÕES OBRIGATÓRIAS ---
 BAT_FILE_PATH = Path(__file__).resolve().parent / "abrir_chrome.bat"
 CDP_ENDPOINT = "http://localhost:9222"
+ASSESSORIA_URL = "https://juridico.bb.com.br/wfj/paginas/negocio/tarefa/listarPendenciaTarefa/listar"
+INFO_REGISTROS_SELECTOR = "div.dataTableNumeroRegistros"
+# Link JSF que gera o relatorio (PDF) com TODAS as solicitacoes de uma vez.
+REPORT_LINK_SELECTOR = "a:has-text('Imprimir Relatório')"
+# No PDF os numeros quebram em 2 linhas (coluna estreita): 'YYYY/NNNNNN' + 'NNNN'.
+# Por isso juntamos os digitos separados por espaco/quebra antes de casar este padrao.
+NUMERO_SOLICITACAO_PDF_PATTERN = re.compile(r"\d{4}/\d{10}")
+
+
+class ErroTecnicoPortal(Exception):
+    pass
+
+
+def pagina_erro_tecnico(page: Page) -> bool:
+    try:
+        if "errodesconhecido.seam" in page.url.lower():
+            return True
+        texto = page.locator("body").inner_text(timeout=1000).lower()
+        return "aconteceu um problema técnico" in texto or "aconteceu um problema tecnico" in texto
+    except Exception:
+        return False
+
+
+def verificar_erro_tecnico(page: Page, contexto: str):
+    if pagina_erro_tecnico(page):
+        raise ErroTecnicoPortal(f"Portal caiu na página de erro técnico durante {contexto}. URL atual: {page.url}")
+
+
+def limpar_cookie_erro_wfj(context):
+    print("    - Limpando somente JSESSIONID do WFJ/raiz...")
+    removidos = 0
+    dominios = ("juridico.bb.com.br", ".juridico.bb.com.br")
+    paths = ("/wfj", "/wfj/", "/")
+
+    try:
+        page = context.pages[0] if context.pages else None
+        cdp = context.new_cdp_session(page) if page else None
+    except Exception:
+        cdp = None
+
+    for dominio in dominios:
+        for path in paths:
+            try:
+                context.clear_cookies(name="JSESSIONID", domain=dominio, path=path)
+                removidos += 1
+                continue
+            except TypeError:
+                pass
+            except Exception:
+                pass
+
+            if cdp:
+                try:
+                    cdp.send("Network.deleteCookies", {"name": "JSESSIONID", "domain": dominio, "path": path})
+                    removidos += 1
+                except Exception:
+                    pass
+
+    print(f"✅ Limpeza seletiva WFJ finalizada ({removidos} remoções solicitadas).")
+
+
+def obter_total_registros(frame) -> int | None:
+    try:
+        texto = frame.locator(INFO_REGISTROS_SELECTOR).first.inner_text(timeout=3000)
+    except Exception:
+        return None
+
+    match = re.search(r"total\s*de\s*(\d+)", texto.lower())
+    if not match:
+        print(f"⚠️ Não foi possível identificar o total no contador: {texto!r}")
+        return None
+
+    total = int(match.group(1))
+    print(f"📊 Total informado pelo portal: {total} registros.")
+    return total
 
 def acessar_assessoria_e_encontrar_frame(page: Page) -> Frame:
     """
@@ -30,10 +106,11 @@ def acessar_assessoria_e_encontrar_frame(page: Page) -> Frame:
     """
     print("[🔁] Acessando seção 'Assessoria - Visão Advogado'...")
     page.goto(
-        "https://juridico.bb.com.br/wfj/paginas/negocio/tarefa/listarPendenciaTarefa/listar",
+        ASSESSORIA_URL,
         timeout=90000,
         wait_until="domcontentloaded"
     )
+    verificar_erro_tecnico(page, "acesso à tela de assessoria")
 
     print("    - Procurando pelo frame que contém o botão de pesquisa...")
     for frame in page.frames:
@@ -52,15 +129,32 @@ def clicar_pesquisar(frame):
     """
     print("[🔍] Clicando no botão 'Pesquisar'...")
     try:
+        verificar_erro_tecnico(frame.page, "pesquisa")
         seletor_botao = "input[type='image'][name='pesquisarPendenciaTarefaForm:btPTarefa']"
 
         print("    - Aguardando o botão de pesquisa...")
         frame.wait_for_selector(seletor_botao, timeout=20000)
 
-        frame.click(seletor_botao)
+        botao_pesquisar = frame.locator(seletor_botao).first
+        try:
+            botao_pesquisar.click(timeout=10000, no_wait_after=True)
+        except TypeError:
+            botao_pesquisar.click(timeout=10000)
+        except Exception:
+            botao_pesquisar.evaluate(
+                """el => {
+                    const event = new MouseEvent('click', {
+                        bubbles: true,
+                        cancelable: true,
+                        view: window
+                    });
+                    el.dispatchEvent(event);
+                }"""
+            )
+        verificar_erro_tecnico(frame.page, "clique em Pesquisar")
 
         print("[⏳] Aguardando carregamento dos registros...")
-        frame.wait_for_selector("div.dataTableNumeroRegistros", timeout=20000)
+        frame.wait_for_selector(INFO_REGISTROS_SELECTOR, timeout=20000)
 
         print("[✅] Registros carregados com sucesso.")
         return True
@@ -68,153 +162,131 @@ def clicar_pesquisar(frame):
         print(f"[❌] Falha ao clicar no botão 'Pesquisar': {e}")
         return False
 
-def alterar_registros_por_pagina(frame):
+def extrair_numeros_do_pdf(caminho_pdf: str) -> set:
+    """Extrai os números de solicitação do relatório PDF (Tarefa.pdf).
+
+    No PDF cada número quebra em duas linhas por causa da coluna estreita
+    (ex.: '2026/000006' + '1732'). Juntamos os dígitos separados por espaço/quebra
+    antes de aplicar o padrão YYYY/NNNNNNNNNN.
     """
-    Função para clicar no botão '50' e aguardar o carregamento da página.
-    
-    """
-    print("\n🔢 Verificando paginação...")
+    from pypdf import PdfReader
+
+    reader = PdfReader(caminho_pdf)
+    texto = "\n".join((pagina.extract_text() or "") for pagina in reader.pages)
+    texto_unido = re.sub(r"(?<=\d)\s+(?=\d)", "", texto)
+    numeros = set(NUMERO_SOLICITACAO_PDF_PATTERN.findall(texto_unido))
+    print(f"[📄] Relatório com {len(reader.pages)} página(s); {len(numeros)} números distintos extraídos.")
+    return numeros
+
+
+def baixar_relatorio_e_extrair(frame: Frame, total_esperado=None) -> set:
+    """Clica em 'Imprimir Relatório', captura o PDF e devolve o conjunto de números."""
+    page = frame.page
+    verificar_erro_tecnico(page, "geração do relatório")
+
+    print("[🖨️] Solicitando 'Imprimir Relatório' (PDF com todas as solicitações)...")
+    frame.wait_for_selector(REPORT_LINK_SELECTOR, timeout=20000)
+    link = frame.locator(REPORT_LINK_SELECTOR).first
+
+    download_timeout = int(os.getenv("RPA_RELATORIO_DOWNLOAD_TIMEOUT_MS", "120000"))
+    with page.expect_download(timeout=download_timeout) as download_info:
+        try:
+            link.click(no_wait_after=True)
+        except Exception:
+            link.evaluate("el => el.click()")
+    download = download_info.value
+
+    destino = Path(tempfile.gettempdir()) / f"onerequest_tarefa_{os.getpid()}.pdf"
+    download.save_as(str(destino))
+    print(f"[✅] Relatório baixado: {download.suggested_filename}")
 
     try:
-        seletor_50 = 'a.dr-dscr-button:has-text("50")'
-        seletor_info = "div.dataTableNumeroRegistros"
-        seletor_linhas = 'tbody#pesquisarPendenciaTarefaForm\\:dataTable\\:tb tr'
-
-        # 1. Verifica se o botão '50' está visível. Se não estiver (ex: só tem 5 registros), segue o fluxo.
-        botao_50 = frame.locator(seletor_50).first
-        if not botao_50.is_visible(timeout=3000):
-            print("⚠️ Botão '50' não encontrado ou não necessário (poucos registros). Mantendo paginação atual.")
-            return True
-
-        # Captura o texto atual antes de clicar para garantir que mudou depois (opcional, mas robusto)
+        numeros = extrair_numeros_do_pdf(str(destino))
+    finally:
         try:
-            texto_inicial = frame.locator(seletor_info).first.inner_text(timeout=2000).strip()
+            destino.unlink()
         except Exception:
-            texto_inicial = ""
+            pass
 
+    if not numeros:
+        raise RuntimeError("Relatório baixado, mas nenhum número de solicitação foi extraído do PDF.")
+
+    if total_esperado:
+        if len(numeros) < total_esperado:
+            raise RuntimeError(
+                f"Relatório incompleto: {len(numeros)} números extraídos de "
+                f"{total_esperado} informados pelo portal."
+            )
+        print(f"[✔️] Validação OK: {len(numeros)}/{total_esperado} (contador do portal).")
+
+    print(f"✅ Coleta concluída. {len(numeros)} solicitações ativas encontradas no portal.")
+    return numeros
+
+
+def preparar_e_baixar_relatorio(portal_page: Page) -> set:
+    tarefa_frame = acessar_assessoria_e_encontrar_frame(portal_page)
+    if not tarefa_frame:
+        raise RuntimeError("Não foi possível encontrar o frame de pesquisa.")
+
+    if not clicar_pesquisar(tarefa_frame):
+        raise RuntimeError("Não foi possível realizar a pesquisa.")
+
+    # Recupera a referência do frame: o postback do Pesquisar pode tê-lo recriado.
+    tarefa_frame = acessar_frame_existente(portal_page) or tarefa_frame
+
+    total_esperado = obter_total_registros(tarefa_frame)
+    return baixar_relatorio_e_extrair(tarefa_frame, total_esperado=total_esperado)
+
+
+def acessar_frame_existente(page: Page) -> Frame | None:
+    """Reobtém o frame que contém o form de pendências (sem renavegar)."""
+    for frame in page.frames:
         try:
-            qtd_linhas_inicial = frame.locator(seletor_linhas).count()
+            if "pesquisarPendenciaTarefaForm" in frame.content():
+                return frame
         except Exception:
-            qtd_linhas_inicial = 0
-
-        print("🖱️  Clicando no botão '50' para expandir registros...")
-        botao_50.click(timeout=10000)
-        
-        print("[⏳] Aguardando atualização da tabela...")
-
-        for _ in range(30): # Tenta por até 15 segundos (30 * 0.5s)
-            texto_atual = ""
-            try:
-                texto_atual = frame.locator(seletor_info).first.inner_text(timeout=1000).strip()
-            except Exception:
-                pass
-
-            if texto_atual and texto_atual != texto_inicial and texto_atual.startswith("1-"):
-                print(f"✅ Paginação atualizada com sucesso. Exibindo: {texto_atual}")
-                return True
-
-            try:
-                qtd_linhas_atual = frame.locator(seletor_linhas).count()
-                if qtd_linhas_atual > qtd_linhas_inicial or qtd_linhas_atual >= 50:
-                    print(f"✅ Paginação atualizada com sucesso. Linhas visíveis: {qtd_linhas_atual}")
-                    return True
-            except Exception:
-                pass
-
-            time.sleep(0.5)
-        
-        try:
-            qtd_linhas_atual = frame.locator(seletor_linhas).count()
-        except Exception:
-            qtd_linhas_atual = 0
-
-        if qtd_linhas_atual > 0:
-            print(f"⚠️ Aviso: não foi possível confirmar a paginação pelo contador, mas há {qtd_linhas_atual} linhas. Prosseguindo.")
-            return True
-
-        print("❌ Não foi possível confirmar a atualização da paginação nem localizar linhas na tabela.")
-        return False
-
-    except Exception as e:
-        print(f"[❌] Falha não bloqueante ao alterar paginação: {e}")
-        # Retornamos True ou False dependendo se você quer que o robô pare. 
-        # Geralmente, falha na paginação não deve parar o robô se ele ainda conseguir ler a página 1.
-        return False
-
-def encontrar_botao_proxima_pagina(frame):
-    """
-    Localiza o botão de próxima página (seta para a direita).
-    """
-    try:
-        botao_proximo = frame.locator('a.mi--chevron-right')
-        if botao_proximo.is_visible() and botao_proximo.is_enabled():
-            return botao_proximo
-    except Exception:
-        pass
-    
+            continue
     return None
 
-def extrair_todos_numeros_solicitacoes(frame):
-    """
-    Extrai todos os números de solicitação de todas as páginas da tabela.
-    """
-    print("\n📋 Extraindo números das solicitações da tabela...")
-    todos_numeros = set()
-    pagina_atual = 1
-    
-    while True:
-        print(f"[📄] Lendo página {pagina_atual}...")
-        
-        linhas = frame.locator('tbody#pesquisarPendenciaTarefaForm\\:dataTable\\:tb tr').all()
-        
-        if not linhas:
-            print("[⚠️] Nenhuma linha encontrada. Fim da extração.")
-            break
-            
-        for linha in linhas:
+
+def coletar_numeros_com_recuperacao(portal_page: Page):
+    max_recuperacoes = int(os.getenv("RPA_COLETA_NUMEROS_MAX_RECUPERACOES", "5"))
+    ultimo_erro = None
+
+    for tentativa in range(1, max_recuperacoes + 1):
+        try:
+            if tentativa > 1:
+                print(f"\n[🔁] Retomando coleta ({tentativa}/{max_recuperacoes})...")
+            return preparar_e_baixar_relatorio(portal_page)
+
+        except ErroTecnicoPortal as exc:
+            ultimo_erro = exc
+            print(f"[⚠️] {exc}")
+            print("    - Limpando cookie problemático e voltando para a lista...")
+            limpar_cookie_erro_wfj(portal_page.context)
+            time.sleep(2)
             try:
-                celula_numero = linha.locator('td').first
-                link_numero = celula_numero.locator('a').first
-                numero = link_numero.inner_text().strip()
-                
-                if numero:
-                    todos_numeros.add(numero)
-                    
-            except Exception as e:
-                print(f"[❌] Erro ao extrair dados da linha: {e}")
+                portal_page.goto(ASSESSORIA_URL, timeout=90000, wait_until="domcontentloaded")
+            except Exception:
+                pass
+            continue
+
+        except Exception as exc:
+            # Falhas transitórias (timeout no Pesquisar, download, etc.): renavega e tenta de novo.
+            ultimo_erro = exc
+            print(f"[⚠️] Falha na coleta (tentativa {tentativa}/{max_recuperacoes}): {exc}")
+            if tentativa < max_recuperacoes:
+                time.sleep(3)
+                try:
+                    portal_page.goto(ASSESSORIA_URL, timeout=90000, wait_until="domcontentloaded")
+                except Exception:
+                    pass
                 continue
-        
-        botao_proximo = encontrar_botao_proxima_pagina(frame)
-        if botao_proximo and botao_proximo.is_visible() and botao_proximo.is_enabled():
-            print(f"[➡️] Passando para a próxima página...")
-            try:
-                primeiro_registro_ref = frame.locator('tbody#pesquisarPendenciaTarefaForm\\:dataTable\\:tb tr').first.inner_text()
-                
-                botao_proximo.click()
 
-                for _ in range(60): 
-                    time.sleep(0.5)
-                    try:
-                        novo_primeiro_registro = frame.locator('tbody#pesquisarPendenciaTarefaForm\\:dataTable\\:tb tr').first.inner_text()
-                        if novo_primeiro_registro != primeiro_registro_ref:
-                            print("✅ Nova página carregada com sucesso!")
-                            break
-                    except:
-                        continue
-                else:
-                    print("[❌] A página não foi carregada com novos dados. Interrompendo a extração.")
-                    break
-
-                pagina_atual += 1
-            except Exception as e:
-                print(f"[❌] Erro ao avançar para a próxima página: {e}")
-                break
-        else:
-            print("[⏹️] Fim da paginação. Todos os números extraídos.")
-            break
-            
-    print(f"✅ Extração concluída. {len(todos_numeros)} solicitações ativas encontradas no portal.")
-    return list(todos_numeros)
+    raise RuntimeError(
+        f"Não foi possível concluir a coleta de números após {max_recuperacoes} tentativas. "
+        f"Último erro: {ultimo_erro}"
+    )
 
 def main():
     """
@@ -223,6 +295,7 @@ def main():
     database.inicializar_banco()
 
     browser_process = None
+    exit_code = 0
     try:
         print(f"▶️  Executando o script: {BAT_FILE_PATH}")
         browser_process = subprocess.Popen(
@@ -250,41 +323,28 @@ def main():
             context = browser.contexts[0]
             portal_page = fazer_login(context)
 
-            tarefa_frame = acessar_assessoria_e_encontrar_frame(portal_page)
+            numeros_atuais_portal = coletar_numeros_com_recuperacao(portal_page)
+
+            # --- Lógica de Sincronização ---
+            print("\n[🔄] Sincronizando status das solicitações com o banco de dados...")
+            numeros_abertos_db = set(database.obter_solicitacoes_abertas_db())
+
+            # 1. Encontra as que foram respondidas
+            respondidas = list(numeros_abertos_db - numeros_atuais_portal)
+            if respondidas:
+                database.marcar_como_respondidas(respondidas)
+                print(f"✅ {len(respondidas)} solicitações foram marcadas como 'Respondido'.")
+
+            # 2. Insere as novas
+            database.inserir_novas_solicitacoes(list(numeros_atuais_portal))
+            print(f"✅ Novas solicitações (se houver) inseridas no banco de dados.")
             
-            if tarefa_frame:
-                if clicar_pesquisar(tarefa_frame):
-                    
-                    if alterar_registros_por_pagina(tarefa_frame):
-                        
-                        numeros_atuais_portal = set(extrair_todos_numeros_solicitacoes(tarefa_frame))
-                        
-                        # --- Lógica de Sincronização ---
-                        print("\n[🔄] Sincronizando status das solicitações com o banco de dados...")
-                        numeros_abertos_db = set(database.obter_solicitacoes_abertas_db())
-
-                        # 1. Encontra as que foram respondidas
-                        respondidas = list(numeros_abertos_db - numeros_atuais_portal)
-                        if respondidas:
-                            database.marcar_como_respondidas(respondidas)
-                            print(f"✅ {len(respondidas)} solicitações foram marcadas como 'Respondido'.")
-
-                        # 2. Insere as novas
-                        database.inserir_novas_solicitacoes(list(numeros_atuais_portal))
-                        print(f"✅ Novas solicitações (se houver) inseridas no banco de dados.")
-                        
-                        # 3. Garante que TODAS as ativas estejam como 'Aberto'
-                        database.marcar_como_abertas(list(numeros_atuais_portal))
-                        print(f"✅ Status de {len(numeros_atuais_portal)} solicitações do portal sincronizado para 'Aberto'.")
-
-                    else:
-                        print("❌ Não foi possível alterar o número de registros por página.")
-                else:
-                    print("❌ Não foi possível realizar a pesquisa. O script será encerrado.")
-            else:
-                print("❌ Não foi possível encontrar o botão de pesquisa. O script será encerrado.")
+            # 3. Garante que TODAS as ativas estejam como 'Aberto'
+            database.marcar_como_abertas(list(numeros_atuais_portal))
+            print(f"✅ Status de {len(numeros_atuais_portal)} solicitações do portal sincronizado para 'Aberto'.")
             
     except Exception as e:
+        exit_code = 1
         print(f"\n========================= ERRO =========================")
         print(f"Ocorreu uma falha na automação: {e}")
         print("========================================================")
@@ -324,6 +384,9 @@ def main():
             print(f"     Aviso: Falha ao tentar finalizar o processo da porta 9222: {e_kill}")
 
         print("--- Rotina de fechamento concluída. Fim da execução. ---")
+
+    if exit_code:
+        sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/RPA/coletaDadosNumeroSolicitacoes.py
+++ b/RPA/coletaDadosNumeroSolicitacoes.py
@@ -77,40 +77,63 @@ def alterar_registros_por_pagina(frame):
 
     try:
         seletor_50 = 'a.dr-dscr-button:has-text("50")'
+        seletor_info = "div.dataTableNumeroRegistros"
+        seletor_linhas = 'tbody#pesquisarPendenciaTarefaForm\\:dataTable\\:tb tr'
 
         # 1. Verifica se o botão '50' está visível. Se não estiver (ex: só tem 5 registros), segue o fluxo.
-        if not frame.locator(seletor_50).is_visible():
+        botao_50 = frame.locator(seletor_50).first
+        if not botao_50.is_visible(timeout=3000):
             print("⚠️ Botão '50' não encontrado ou não necessário (poucos registros). Mantendo paginação atual.")
             return True
 
         # Captura o texto atual antes de clicar para garantir que mudou depois (opcional, mas robusto)
-        seletor_info = "div.dataTableNumeroRegistros"
         try:
-            texto_inicial = frame.locator(seletor_info).first.inner_text()
-        except:
+            texto_inicial = frame.locator(seletor_info).first.inner_text(timeout=2000).strip()
+        except Exception:
             texto_inicial = ""
 
+        try:
+            qtd_linhas_inicial = frame.locator(seletor_linhas).count()
+        except Exception:
+            qtd_linhas_inicial = 0
+
         print("🖱️  Clicando no botão '50' para expandir registros...")
-        frame.click(seletor_50, timeout=10000)
+        botao_50.click(timeout=10000)
         
         print("[⏳] Aguardando atualização da tabela...")
 
-        # 2. Espera genérica: aguarda o elemento de contagem estar visível novamente
-        # Não usamos has-text("1-50") pois pode ser "1-30", "1-12", etc.
-        frame.wait_for_selector(seletor_info, state="visible", timeout=30000)
+        for _ in range(30): # Tenta por até 15 segundos (30 * 0.5s)
+            texto_atual = ""
+            try:
+                texto_atual = frame.locator(seletor_info).first.inner_text(timeout=1000).strip()
+            except Exception:
+                pass
 
-        # 3. Validação extra: Aguarda o texto começar com "1-" (ex: 1-50, 1-30)
-        # Isso confirma que a tabela foi carregada, independente da quantidade total.
-        # O loop abaixo garante que não pegamos o texto antigo por azar.
-        for _ in range(20): # Tenta por até 10 segundos (20 * 0.5s)
-            texto_atual = frame.locator(seletor_info).first.inner_text().strip()
-            if texto_atual != texto_inicial and texto_atual.startswith("1-"):
+            if texto_atual and texto_atual != texto_inicial and texto_atual.startswith("1-"):
                 print(f"✅ Paginação atualizada com sucesso. Exibindo: {texto_atual}")
                 return True
+
+            try:
+                qtd_linhas_atual = frame.locator(seletor_linhas).count()
+                if qtd_linhas_atual > qtd_linhas_inicial or qtd_linhas_atual >= 50:
+                    print(f"✅ Paginação atualizada com sucesso. Linhas visíveis: {qtd_linhas_atual}")
+                    return True
+            except Exception:
+                pass
+
             time.sleep(0.5)
         
-        print(f"⚠️ Aviso: O texto da paginação não mudou ({texto_inicial}), mas o elemento está visível. Prosseguindo.")
-        return True
+        try:
+            qtd_linhas_atual = frame.locator(seletor_linhas).count()
+        except Exception:
+            qtd_linhas_atual = 0
+
+        if qtd_linhas_atual > 0:
+            print(f"⚠️ Aviso: não foi possível confirmar a paginação pelo contador, mas há {qtd_linhas_atual} linhas. Prosseguindo.")
+            return True
+
+        print("❌ Não foi possível confirmar a atualização da paginação nem localizar linhas na tabela.")
+        return False
 
     except Exception as e:
         print(f"[❌] Falha não bloqueante ao alterar paginação: {e}")

--- a/RPA/coletaDadosNumeroSolicitacoes.py
+++ b/RPA/coletaDadosNumeroSolicitacoes.py
@@ -14,6 +14,9 @@ sys.path.insert(0, project_root)
 
 from bd import database
 from portal_bb import fazer_login
+from observability import install_print_logger
+
+install_print_logger("robo-coleta-numeros")
 
 
 

--- a/RPA/coletaDetalhesSolicitacoes.py
+++ b/RPA/coletaDetalhesSolicitacoes.py
@@ -14,6 +14,9 @@ sys.path.insert(0, project_root)
 # Importa o módulo da pasta 'bd'
 from bd import database
 from portal_bb import abrir_popup_dmi, fazer_login
+from observability import install_print_logger
+
+install_print_logger("robo-detalhes-legado")
 
 # --- CONFIGURAÇÕES OBRIGATÓRIAS ---
 BAT_FILE_PATH = Path(__file__).resolve().parent / "abrir_chrome.bat"

--- a/RPA/main.py
+++ b/RPA/main.py
@@ -12,6 +12,29 @@ from bd import database
 logger = install_print_logger("robo-detalhes")
 
 
+def _fechar_paginas_extras(portal_page):
+    """Fecha popups/abas remanescentes, mantendo apenas a aba principal do portal."""
+    for page in list(portal_page.context.pages):
+        if page != portal_page:
+            try:
+                page.close()
+            except Exception:
+                pass
+
+
+def _marcar_acesso_negado(numero):
+    """Registra a solicitacao como 'Acesso nao autorizado' para sair da fila de pendentes."""
+    database.atualizar_detalhes_solicitacao({
+        "numero_solicitacao": numero,
+        "titulo": "Acesso não autorizado",
+        "npj_direcionador": "",
+        "prazo": "",
+        "texto_dmi": "Advogado terceirizado não cadastrado no portal. Contatar a Ajure de relacionamento.",
+        "numero_processo": "Acesso não autorizado",
+        "polo": "N/A",
+    })
+
+
 def processar_com_retentativas(portal_page, numero, max_tentativas, espera_segundos):
     ultimo_erro = None
     for tentativa in range(1, max_tentativas + 1):
@@ -35,6 +58,22 @@ def processar_com_retentativas(portal_page, numero, max_tentativas, espera_segun
                 status="success",
             )
             return True
+        except portal_bb.AcessoNaoAutorizadoError as exc:
+            # Erro permanente: repetir nao resolve. Marca, registra e segue para a proxima.
+            print(f"⛔ {numero}: acesso não autorizado (advogado não cadastrado no portal). Marcando e seguindo.")
+            log_event(
+                logger,
+                f"Acesso não autorizado para a solicitacao: {exc}",
+                solicitacao=numero,
+                attempt=tentativa,
+                status="skipped",
+            )
+            try:
+                _marcar_acesso_negado(numero)
+            except Exception as db_exc:
+                print(f"    ⚠️ Falha ao marcar acesso negado de {numero}: {db_exc}")
+            _fechar_paginas_extras(portal_page)
+            return False
         except Exception as exc:
             ultimo_erro = exc
             log_event(
@@ -47,12 +86,7 @@ def processar_com_retentativas(portal_page, numero, max_tentativas, espera_segun
             if tentativa < max_tentativas:
                 print(f"⚠️ Tentativa {tentativa}/{max_tentativas} falhou para {numero}: {exc}")
                 print(f"    - Aguardando {espera_segundos}s antes de tentar novamente...")
-                for page in list(portal_page.context.pages):
-                    if page != portal_page:
-                        try:
-                            page.close()
-                        except Exception:
-                            pass
+                _fechar_paginas_extras(portal_page)
                 time.sleep(espera_segundos)
                 continue
             print(f"❌ Erro ao processar {numero} após {max_tentativas} tentativas: {ultimo_erro}")

--- a/RPA/main.py
+++ b/RPA/main.py
@@ -1,14 +1,68 @@
 import sys
 import os
+import time
 from navegador import Navegador
 import portal_bb
+from observability import install_print_logger, log_event, push_robot_metrics
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, project_root)
 from bd import database
 
+logger = install_print_logger("robo-detalhes")
+
+
+def processar_com_retentativas(portal_page, numero, max_tentativas, espera_segundos):
+    ultimo_erro = None
+    for tentativa in range(1, max_tentativas + 1):
+        try:
+            if tentativa > 1:
+                print(f"    - Nova tentativa {tentativa}/{max_tentativas} para {numero}...")
+            log_event(
+                logger,
+                "Iniciando processamento da solicitacao.",
+                solicitacao=numero,
+                attempt=tentativa,
+                status="started",
+            )
+            dados_completos = portal_bb.coletar_detalhes(portal_page, numero)
+            database.atualizar_detalhes_solicitacao(dados_completos)
+            log_event(
+                logger,
+                "Solicitacao atualizada com sucesso.",
+                solicitacao=numero,
+                attempt=tentativa,
+                status="success",
+            )
+            return True
+        except Exception as exc:
+            ultimo_erro = exc
+            log_event(
+                logger,
+                f"Falha ao processar solicitacao: {exc}",
+                solicitacao=numero,
+                attempt=tentativa,
+                status="error",
+            )
+            if tentativa < max_tentativas:
+                print(f"⚠️ Tentativa {tentativa}/{max_tentativas} falhou para {numero}: {exc}")
+                print(f"    - Aguardando {espera_segundos}s antes de tentar novamente...")
+                for page in list(portal_page.context.pages):
+                    if page != portal_page:
+                        try:
+                            page.close()
+                        except Exception:
+                            pass
+                time.sleep(espera_segundos)
+                continue
+            print(f"❌ Erro ao processar {numero} após {max_tentativas} tentativas: {ultimo_erro}")
+            return False
+
+
 def run():
     """Função principal que orquestra todo o processo de RPA."""
+    inicio = time.monotonic()
+    log_event(logger, "Execucao do robo de detalhes iniciada.", status="started")
     
     # 1. Inicializa o banco de dados
     database.inicializar_banco()
@@ -17,6 +71,8 @@ def run():
     solicitacoes_pendentes = database.obter_solicitacoes_pendentes()
     if not solicitacoes_pendentes:
         print("✅ Nenhuma solicitação pendente encontrada. Trabalho concluído!")
+        log_event(logger, "Robo de detalhes finalizado sem pendencias.", status="success")
+        push_robot_metrics("robo-detalhes", "success", duration_seconds=time.monotonic() - inicio, successes=0, failures=0)
         return
     print(f"📂 {len(solicitacoes_pendentes)} solicitações pendentes para processar.")
 
@@ -30,24 +86,39 @@ def run():
 
         # 5. Processa cada solicitação pendente
         total = len(solicitacoes_pendentes)
+        max_tentativas = int(os.getenv("RPA_DETALHES_MAX_TENTATIVAS", "3"))
+        espera_segundos = int(os.getenv("RPA_DETALHES_ESPERA_RETRY_SEGUNDOS", "10"))
+        sucessos = 0
+        falhas = 0
         for i, numero in enumerate(solicitacoes_pendentes):
             print(f"\n[🔄] Processando {i+1}/{total}: {numero}")
-            try:
-                dados_completos = portal_bb.coletar_detalhes(portal_page, numero)
-                
-                # Usa a nova função para ATUALIZAR os detalhes no banco de dados
-                database.atualizar_detalhes_solicitacao(dados_completos)
-                
+            if processar_com_retentativas(portal_page, numero, max_tentativas, espera_segundos):
+                sucessos += 1
                 print(f"✅ Dados de {numero} atualizados com sucesso!")
-            except Exception as e:
-                print(f"❌ Erro ao processar {numero}: {e}")
+            else:
+                falhas += 1
         
         print("\n🏁 Fim da coleta de dados detalhados.")
+        status = "success" if falhas == 0 else "partial_failure"
+        log_event(
+            logger,
+            f"Execucao do robo de detalhes finalizada. sucessos={sucessos} falhas={falhas} duracao_s={time.monotonic() - inicio:.1f}",
+            status=status,
+        )
+        push_robot_metrics(
+            "robo-detalhes",
+            status,
+            duration_seconds=time.monotonic() - inicio,
+            successes=sucessos,
+            failures=falhas,
+        )
 
     except Exception as e:
         print(f"\n========================= ERRO CRÍTICO =========================")
         print(f"Ocorreu uma falha na automação: {e}")
         print(f"================================================================")
+        log_event(logger, f"Erro critico no robo de detalhes: {e}", status="critical_error")
+        push_robot_metrics("robo-detalhes", "critical_error", duration_seconds=time.monotonic() - inicio)
     finally:
         # 6. Fecha o navegador
         print("\n... Fechando o navegador e encerrando o script ...")

--- a/RPA/observability.py
+++ b/RPA/observability.py
@@ -1,0 +1,199 @@
+import builtins
+import json
+import logging
+import os
+import socket
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+try:
+    import requests
+except Exception:
+    requests = None
+
+
+_ORIGINAL_PRINT = builtins.print
+_CONFIGURED = False
+
+
+class ContextLoggerAdapter(logging.LoggerAdapter):
+    def process(self, msg, kwargs):
+        extra = dict(self.extra)
+        extra.update(kwargs.pop("extra", {}) or {})
+        kwargs["extra"] = extra
+        return msg, kwargs
+
+
+def carregar_env_local():
+    project_root = Path(__file__).resolve().parent.parent
+    for env_path in (project_root / ".env", Path(__file__).resolve().parent / ".env"):
+        if not env_path.exists():
+            continue
+        for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
+
+
+class LokiHandler(logging.Handler):
+    def __init__(self, url, labels):
+        super().__init__()
+        self.url = url
+        self.labels = labels
+        self.timeout = float(os.getenv("LOKI_TIMEOUT_SECONDS", "2"))
+
+    def emit(self, record):
+        labels = dict(self.labels)
+        for key in ("robot", "run_id", "status", "solicitacao", "attempt"):
+            value = getattr(record, key, None)
+            if value is not None:
+                labels[key] = str(value)
+
+        payload = {
+            "streams": [
+                {
+                    "stream": labels,
+                    "values": [[str(time.time_ns()), self.format(record)]],
+                }
+            ]
+        }
+
+        try:
+            body = json.dumps(payload).encode("utf-8")
+            if requests:
+                requests.post(self.url, data=body, headers={"Content-Type": "application/json"}, timeout=self.timeout)
+            else:
+                request = Request(self.url, data=body, headers={"Content-Type": "application/json"}, method="POST")
+                with urlopen(request, timeout=self.timeout):
+                    pass
+        except Exception:
+            pass
+
+
+def setup_logging(robot_name="onerequest", run_id=None):
+    global _CONFIGURED
+    carregar_env_local()
+
+    logger = logging.getLogger("onerequest")
+    logger.setLevel(os.getenv("LOG_LEVEL", "INFO").upper())
+    logger.propagate = False
+
+    if not _CONFIGURED:
+        formatter = logging.Formatter("%(message)s")
+
+        try:
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
+
+        console = logging.StreamHandler(sys.stdout)
+        console.setFormatter(formatter)
+        logger.addHandler(console)
+
+        loki_url = os.getenv("LOKI_URL")
+        if loki_url:
+            labels = {
+                "application": os.getenv("LOKI_APPLICATION", "onerequest-rpa"),
+                "env": os.getenv("APP_ENV", "local"),
+                "host": os.getenv("APP_HOST_IP") or socket.gethostbyname(socket.gethostname()),
+            }
+            loki = LokiHandler(loki_url, labels)
+            loki.setFormatter(formatter)
+            logger.addHandler(loki)
+
+        _CONFIGURED = True
+
+    if not run_id:
+        run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    return ContextLoggerAdapter(logger, {"robot": robot_name, "run_id": run_id})
+
+
+def install_print_logger(robot_name="onerequest", run_id=None):
+    logger = setup_logging(robot_name=robot_name, run_id=run_id)
+
+    def print_logger(*args, sep=" ", end="\n", file=None, flush=False):
+        if file not in (None, sys.stdout):
+            _ORIGINAL_PRINT(*args, sep=sep, end=end, file=file, flush=flush)
+            return
+        message = sep.join(str(arg) for arg in args)
+        if end and end != "\n":
+            message += end
+        logger.info(message)
+        if flush:
+            for handler in logger.logger.handlers:
+                handler.flush()
+
+    builtins.print = print_logger
+    return logger
+
+
+def log_event(logger, message, **extra):
+    logger.info(message, extra=extra)
+
+
+def _label_value(value):
+    return str(value).replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ")
+
+
+def push_robot_metrics(robot_name, status, *, duration_seconds=None, successes=None, failures=None):
+    carregar_env_local()
+    pushgateway_url = os.getenv("PUSHGATEWAY_URL")
+    if not pushgateway_url:
+        return
+
+    labels = f'robot="{_label_value(robot_name)}",application="{_label_value(os.getenv("LOKI_APPLICATION", "onerequest-rpa"))}"'
+    status_labels = f'{labels},status="{_label_value(status)}"'
+    now = time.time()
+    lines = [
+        "# TYPE onerequest_robot_last_run_timestamp_seconds gauge",
+        f"onerequest_robot_last_run_timestamp_seconds{{{status_labels}}} {now}",
+        "# TYPE onerequest_robot_last_status gauge",
+        f"onerequest_robot_last_status{{{status_labels}}} 1",
+    ]
+
+    if status == "success":
+        lines.extend(
+            [
+                "# TYPE onerequest_robot_last_success_timestamp_seconds gauge",
+                f"onerequest_robot_last_success_timestamp_seconds{{{labels}}} {now}",
+            ]
+        )
+
+    if duration_seconds is not None:
+        lines.extend(
+            [
+                "# TYPE onerequest_robot_last_duration_seconds gauge",
+                f"onerequest_robot_last_duration_seconds{{{status_labels}}} {float(duration_seconds):.3f}",
+            ]
+        )
+
+    if successes is not None:
+        lines.extend(
+            [
+                "# TYPE onerequest_robot_last_successful_items gauge",
+                f"onerequest_robot_last_successful_items{{{labels}}} {int(successes)}",
+            ]
+        )
+
+    if failures is not None:
+        lines.extend(
+            [
+                "# TYPE onerequest_robot_last_failed_items gauge",
+                f"onerequest_robot_last_failed_items{{{labels}}} {int(failures)}",
+            ]
+        )
+
+    body = ("\n".join(lines) + "\n").encode("utf-8")
+    url = pushgateway_url.rstrip("/") + f"/metrics/job/onerequest/robot/{robot_name}"
+    try:
+        request = Request(url, data=body, headers={"Content-Type": "text/plain; version=0.0.4"}, method="PUT")
+        with urlopen(request, timeout=float(os.getenv("PUSHGATEWAY_TIMEOUT_SECONDS", "2"))):
+            pass
+    except Exception:
+        pass

--- a/RPA/onelog_client.py
+++ b/RPA/onelog_client.py
@@ -1,0 +1,148 @@
+import os
+import time
+
+import requests
+
+
+DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+DEFAULT_API_URL = "http://api-onelog.mdradvocacia.com"
+HEARTBEAT_INTERVAL_SECONDS = 15 * 60
+
+_last_heartbeat = 0
+_current_sector = None
+
+
+def is_configured():
+    return bool(os.getenv("ONELOG_USERNAME")) and bool(os.getenv("ONELOG_PASSWORD"))
+
+
+def get_session():
+    global _current_sector
+
+    username = os.getenv("ONELOG_USERNAME")
+    password = os.getenv("ONELOG_PASSWORD")
+    api_url = os.getenv("ONELOG_API_URL", DEFAULT_API_URL).rstrip("/")
+    user_agent = os.getenv("ONELOG_USER_AGENT", DEFAULT_USER_AGENT)
+
+    if not username or not password:
+        raise ValueError("Credenciais ONELOG_USERNAME/ONELOG_PASSWORD não configuradas")
+
+    payload = {
+        "username": username,
+        "password": password,
+        "user_agent": user_agent,
+    }
+
+    print("🔑 Solicitando sessão autenticada ao OneLog...")
+    login_response = requests.post(
+        f"{api_url}/api/zerocore/login",
+        json=payload,
+        timeout=int(os.getenv("ONELOG_REQUEST_TIMEOUT", "15")),
+    )
+    if login_response.status_code in {401, 403}:
+        message = _response_message(login_response)
+        raise PermissionError(f"Acesso negado no OneLog: {message}")
+    login_response.raise_for_status()
+
+    login_data = login_response.json()
+    _current_sector = login_data.get("setor")
+
+    if login_data.get("status") == "sucesso":
+        print("✅ OneLog retornou sessão pronta.")
+        return {
+            "cookies": login_data.get("cookies", []),
+            "user_agent": login_data.get("user_agent") or user_agent,
+        }
+
+    print("⏳ Login enfileirado no OneLog. Aguardando conclusão...")
+    max_attempts = int(os.getenv("ONELOG_STATUS_ATTEMPTS", "150"))
+    poll_seconds = float(os.getenv("ONELOG_STATUS_INTERVAL_SECONDS", "2"))
+
+    for _ in range(max_attempts):
+        time.sleep(poll_seconds)
+        status_response = requests.get(
+            f"{api_url}/api/zerocore/status",
+            params={"setor": _current_sector},
+            timeout=int(os.getenv("ONELOG_REQUEST_TIMEOUT", "15")),
+        )
+        status_response.raise_for_status()
+        status_data = status_response.json()
+
+        if status_data.get("mensagem"):
+            print(f"    [OneLog] {status_data['mensagem']}")
+        if status_data.get("erro"):
+            raise RuntimeError("OneLog informou falha ao autenticar no portal")
+        if status_data.get("concluido"):
+            return _fetch_final_session(api_url, username, password, _current_sector, user_agent)
+
+    raise TimeoutError("Tempo limite esgotado aguardando sessão do OneLog")
+
+
+def renew_session():
+    global _last_heartbeat
+
+    if not is_configured():
+        return False
+
+    now = time.time()
+    if now - _last_heartbeat < HEARTBEAT_INTERVAL_SECONDS:
+        return True
+    if not _current_sector:
+        return False
+
+    api_url = os.getenv("ONELOG_API_URL", DEFAULT_API_URL).rstrip("/")
+    payload = {
+        "username": os.getenv("ONELOG_USERNAME"),
+        "password": os.getenv("ONELOG_PASSWORD"),
+        "setor": _current_sector,
+        "user_agent": os.getenv("ONELOG_USER_AGENT", DEFAULT_USER_AGENT),
+    }
+
+    try:
+        response = requests.post(
+            f"{api_url}/api/zerocore/renew",
+            json=payload,
+            timeout=int(os.getenv("ONELOG_REQUEST_TIMEOUT", "15")),
+        )
+        response.raise_for_status()
+        _last_heartbeat = now
+        print("💓 Marcapasso OneLog enviado.")
+        return True
+    except Exception as exc:
+        print(f"⚠️ Falha ao renovar sessão no OneLog: {exc}")
+        return False
+
+
+def _fetch_final_session(api_url, username, password, sector, default_user_agent):
+    payload = {
+        "username": username,
+        "password": password,
+        "setor": sector,
+    }
+    response = requests.post(
+        f"{api_url}/api/zerocore/session",
+        json=payload,
+        timeout=int(os.getenv("ONELOG_REQUEST_TIMEOUT", "15")),
+    )
+    response.raise_for_status()
+    session_data = response.json()
+
+    if session_data.get("status") != "sucesso":
+        raise RuntimeError("OneLog não retornou uma sessão final válida")
+
+    print("✅ Cookies resgatados do OneLog.")
+    return {
+        "cookies": session_data.get("cookies", []),
+        "user_agent": session_data.get("user_agent") or default_user_agent,
+    }
+
+
+def _response_message(response):
+    try:
+        data = response.json()
+        return data.get("mensagem") or data.get("message") or response.text
+    except Exception:
+        return response.text

--- a/RPA/portal_bb.py
+++ b/RPA/portal_bb.py
@@ -261,6 +261,13 @@ def limpar_cookies_sessao_portal(context):
     print(f"✅ Limpeza de cookies de sessão finalizada ({removidos} remoções solicitadas).")
 
 
+def deve_limpar_cookies_antes_login() -> bool:
+    return os.getenv(
+        "RPA_LIMPAR_COOKIES_ANTES_LOGIN",
+        os.getenv("RPA_LIMPAR_COOKIES_APOS_LOGIN", "1"),
+    ) == "1"
+
+
 def abrir_popup_dmi(page: Page):
     botao_detalhar = page.locator("#detalhar\\:j_id106").first
     timeout_botao = int(os.getenv("RPA_DMI_BOTAO_TIMEOUT_MS", "30000"))
@@ -302,6 +309,11 @@ def fazer_login(context) -> Page:
 
         print("🚀 Iniciando login direto no SSO do Portal Jurídico...")
         portal_page = context.pages[0] if context.pages else context.new_page()
+
+        if deve_limpar_cookies_antes_login():
+            print("    - Limpando cookies de sessão antes de iniciar novo login...")
+            limpar_cookies_sessao_portal(context)
+
         portal_page.goto(LOGIN_URL, timeout=90000, wait_until="domcontentloaded")
         aguardar_documento(portal_page, timeout=30000)
 
@@ -347,8 +359,6 @@ def fazer_login(context) -> Page:
         print("    - Verificacao de login bem-sucedida! Elemento 'Portal Juridico' encontrado.")
 
         print("\n✅ PROCESSO DE LOGIN FINALIZADO.")
-        
-        limpar_cookies_sessao_portal(context)
         return portal_page
 
     except TimeoutError as e:
@@ -358,6 +368,109 @@ def fazer_login(context) -> Page:
     except Exception as e:
         print(f"\n❌ FALHA inesperada durante o login: {e}")
         raise e
+
+
+def extrair_dados_processo_api(api_data: dict) -> tuple[str, str, bool]:
+    dados = api_data.get("data", {})
+    numero_processo = (
+        dados.get("textoNumeroInventario")
+        or dados.get("textoNumeroExternoProcesso")
+        or "Dado ausente na API"
+    )
+    polo_indicador = dados.get("indicadorPoloBanco", "")
+    polo_map = {"A": "Ativo", "P": "Passivo", "N": "Neutro"}
+    return numero_processo, polo_map.get(polo_indicador, "Não definido"), False
+
+
+def dados_processo_por_status(status: int, api_data: dict | None = None) -> tuple[str, str, bool]:
+    if 200 <= status < 300 and api_data:
+        return extrair_dados_processo_api(api_data)
+
+    if status in (401, 403, 408, 429) or status >= 500:
+        return f"Consulta pendente (API {status})", "Pendente", True
+
+    return f"Processo não encontrado (API {status})", "N/A", False
+
+
+def dados_processo_por_resposta(response) -> tuple[str, str, bool]:
+    if response.ok:
+        return extrair_dados_processo_api(response.json())
+
+    return dados_processo_por_status(response.status)
+
+
+def consultar_dados_processo_no_navegador(page: Page, api_url: str) -> tuple[str, str, bool]:
+    """Executa a consulta dentro da pagina logada, preservando cookies/tokens do navegador."""
+    resultado = page.evaluate(
+        """async (url) => {
+            const response = await fetch(url, {
+                method: "GET",
+                credentials: "include",
+                headers: {
+                    "Accept": "application/json, text/plain, */*"
+                }
+            });
+
+            const text = await response.text();
+            let data = null;
+            try {
+                data = text ? JSON.parse(text) : null;
+            } catch (error) {
+                data = null;
+            }
+
+            return {
+                ok: response.ok,
+                status: response.status,
+                data,
+                bodyPreview: text.slice(0, 300)
+            };
+        }""",
+        api_url,
+    )
+
+    if resultado["ok"]:
+        return extrair_dados_processo_api(resultado["data"] or {})
+
+    status = resultado["status"]
+    if status in (401, 403):
+        print(f"    - Fetch no navegador tambem retornou {status}. Previa: {resultado['bodyPreview']}")
+    return dados_processo_por_status(status, resultado.get("data"))
+
+
+def aquecer_sessao_paj(page: Page):
+    sessao_page = page.context.new_page()
+    try:
+        sessao_page.goto(
+            PORTAL_HOME_URL,
+            timeout=int(os.getenv("RPA_API_AQUECER_SESSAO_TIMEOUT_MS", "60000")),
+            wait_until="domcontentloaded",
+        )
+    finally:
+        sessao_page.close()
+
+
+def consultar_dados_processo(page: Page, npj_limpo: str) -> tuple[str, str, bool]:
+    """Consulta os dados do processo na API usando a mesma sessao do navegador."""
+    api_url = f"https://juridico.bb.com.br/paj/resources/app/v1/processo/consulta/{npj_limpo}"
+    timeout = int(os.getenv("RPA_API_PROCESSO_TIMEOUT_MS", "30000"))
+    headers = {
+        "Accept": "application/json, text/plain, */*",
+        "Referer": PORTAL_HOME_URL,
+    }
+
+    response = page.context.request.get(api_url, headers=headers, timeout=timeout)
+    if response.status not in (401, 403):
+        return dados_processo_por_resposta(response)
+
+    print(f"    - API retornou {response.status}; renovando sessao PAJ e tentando novamente...")
+    aquecer_sessao_paj(page)
+    response = page.context.request.get(api_url, headers=headers, timeout=timeout)
+    if response.status not in (401, 403):
+        return dados_processo_por_resposta(response)
+
+    print(f"    - API via request ainda retornou {response.status}; tentando fetch dentro do navegador...")
+    return consultar_dados_processo_no_navegador(page, api_url)
 
 
 def coletar_detalhes(page: Page, numero_solicitacao: str) -> dict:
@@ -406,30 +519,15 @@ def coletar_detalhes(page: Page, numero_solicitacao: str) -> dict:
     if dados_solicitacao["npj_direcionador"]:
         npj_base = dados_solicitacao["npj_direcionador"].split('-')[0]
         npj_limpo = npj_base.replace('/', '')
-        api_url = f"https://juridico.bb.com.br/paj/resources/app/v1/processo/consulta/{npj_limpo}"
 
-        api_page = page.context.new_page()
         try:
-            api_response = api_page.goto(api_url, timeout=30000, wait_until="domcontentloaded")
-
-            if api_response and api_response.ok:
-                api_data = api_page.evaluate("() => JSON.parse(document.body.innerText)")
-
-                dados_solicitacao["numero_processo"] = api_data.get("data", {}).get("textoNumeroInventario", "Dado ausente na API")
-
-                polo_indicador = api_data.get("data", {}).get("indicadorPoloBanco", "")
-                polo_map = {"A": "Ativo", "P": "Passivo", "N": "Neutro"}
-                dados_solicitacao["polo"] = polo_map.get(polo_indicador, "Não definido")
-
-            else:
-                status = api_response.status if api_response else "sem resposta"
-                dados_solicitacao["numero_processo"] = f"Processo não encontrado (API {status})"
-                dados_solicitacao["polo"] = "N/A"
+            numero_processo, polo, _retry_later = consultar_dados_processo(page, npj_limpo)
+            dados_solicitacao["numero_processo"] = numero_processo
+            dados_solicitacao["polo"] = polo
         except Exception as exc:
-            dados_solicitacao["numero_processo"] = f"Erro na API: {exc}"
-            dados_solicitacao["polo"] = "Erro na API"
-        finally:
-            api_page.close()
+            print(f"    - Consulta da API falhou; sera tentada novamente no proximo ciclo: {exc}")
+            dados_solicitacao["numero_processo"] = "Consulta pendente"
+            dados_solicitacao["polo"] = "Pendente"
     else:
         dados_solicitacao["numero_processo"] = "NPJ não informado"
         dados_solicitacao["polo"] = "N/A"

--- a/RPA/portal_bb.py
+++ b/RPA/portal_bb.py
@@ -4,6 +4,8 @@ import os
 import time
 from playwright.sync_api import Page, Frame, TimeoutError
 
+import onelog_client
+
 LOGIN_URL = (
     "https://loginweb.bb.com.br/sso/XUI/?realm=/paj"
     "&goto=https://juridico.bb.com.br/wfj#login"
@@ -298,10 +300,110 @@ def abrir_popup_dmi(page: Page):
             raise click_error
 
 
-def fazer_login(context) -> Page:
-    """
-    Realiza login direto no Portal Jurídico usando credenciais do ambiente.
-    """
+def _formatar_cookie_para_playwright(cookie):
+    """Converte um cookie do OneLog para o formato esperado pelo Playwright."""
+    name = cookie.get("name")
+    value = cookie.get("value")
+    domain = cookie.get("domain")
+    if not name or value is None or not domain:
+        return None
+
+    formatado = {
+        "name": name,
+        "value": str(value),
+        "domain": domain,
+        "path": cookie.get("path") or "/",
+        "secure": bool(cookie.get("secure", True)),
+        "httpOnly": bool(cookie.get("httpOnly", cookie.get("http_only", False))),
+    }
+
+    expires = cookie.get("expires") or cookie.get("expiry") or cookie.get("expirationDate")
+    if expires:
+        try:
+            formatado["expires"] = float(expires)
+        except (TypeError, ValueError):
+            pass
+
+    same_site = cookie.get("sameSite") or cookie.get("same_site")
+    if same_site:
+        normalized = str(same_site).strip().capitalize()
+        if normalized in {"Strict", "Lax", "None"}:
+            formatado["sameSite"] = normalized
+
+    return formatado
+
+
+def _injetar_cookies_onelog(context, cookies):
+    """Injeta cookies recebidos do OneLog no contexto do Playwright."""
+    if not cookies:
+        raise RuntimeError("OneLog não retornou cookies")
+
+    cookies_formatados = []
+    for cookie in cookies:
+        formatado = _formatar_cookie_para_playwright(cookie)
+        if formatado:
+            cookies_formatados.append(formatado)
+
+    if not cookies_formatados:
+        raise RuntimeError("Nenhum cookie do OneLog pôde ser formatado para o Playwright")
+
+    context.add_cookies(cookies_formatados)
+    print(f"🍪 {len(cookies_formatados)} cookies injetados a partir do OneLog.")
+
+
+def fazer_login_onelog(context) -> Page:
+    """Realiza login via OneLog: obtém cookies autenticados e injeta no navegador."""
+    try:
+        print("🚀 Iniciando login via OneLog...")
+        session_data = onelog_client.get_session()
+        cookies = session_data.get("cookies") or []
+        user_agent = session_data.get("user_agent")
+
+        portal_page = context.pages[0] if context.pages else context.new_page()
+
+        if user_agent:
+            try:
+                cdp = context.new_cdp_session(portal_page)
+                cdp.send("Network.setUserAgentOverride", {"userAgent": user_agent})
+                print(f"    - User-Agent do OneLog aplicado.")
+            except Exception as exc:
+                print(f"    ⚠️ Não foi possível aplicar user-agent do OneLog: {exc}")
+
+        _injetar_cookies_onelog(context, cookies)
+
+        print("    - Navegando para o portal com cookies injetados...")
+        portal_page.goto(PORTAL_HOME_URL, timeout=90000, wait_until="domcontentloaded")
+        aguardar_documento(portal_page, timeout=30000)
+
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            url_atual = portal_page.url.lower()
+            if any(hint in url_atual for hint in LOGIN_URL_HINTS):
+                time.sleep(0.5)
+                continue
+            if pagina_erro_acesso(portal_page):
+                raise RuntimeError("Portal retornou página de erro após injeção de cookies do OneLog.")
+            if portal_principal_visivel(portal_page):
+                break
+            time.sleep(0.5)
+        else:
+            raise TimeoutError(
+                "Autenticação via OneLog não foi confirmada. "
+                f"URL atual: {portal_page.url}. Prévia: {texto_pagina(portal_page)[:300]}"
+            )
+
+        onelog_client.renew_session()
+        print("    - Verificação de login bem-sucedida! Elemento 'Portal Jurídico' encontrado.")
+        print("\n✅ PROCESSO DE LOGIN VIA ONELOG FINALIZADO.")
+        return portal_page
+
+    except Exception as e:
+        print(f"\n❌ FALHA no login via OneLog: {e}")
+        raise e
+
+
+def fazer_login_direto(context) -> Page:
+    """Realiza login direto no Portal Jurídico usando credenciais do ambiente (fallback)."""
     try:
         usuario, senha = obter_credenciais()
         login_timeout = int(os.getenv("RPA_LOGIN_TIMEOUT", "60")) * 1000
@@ -368,6 +470,19 @@ def fazer_login(context) -> Page:
     except Exception as e:
         print(f"\n❌ FALHA inesperada durante o login: {e}")
         raise e
+
+
+def fazer_login(context) -> Page:
+    """
+    Realiza login no Portal Jurídico.
+    Prefere OneLog quando configurado; caso contrário, faz login direto via SSO.
+    """
+    if onelog_client.is_configured():
+        print("🔐 OneLog configurado. Usando autenticação via cookies do OneLog.")
+        return fazer_login_onelog(context)
+
+    print("🔐 OneLog não configurado. Usando login direto no SSO.")
+    return fazer_login_direto(context)
 
 
 def extrair_dados_processo_api(api_data: dict) -> tuple[str, str, bool]:

--- a/RPA/portal_bb.py
+++ b/RPA/portal_bb.py
@@ -18,6 +18,27 @@ ACCESS_ERROR_SECURITY_HINTS = ("identificador de seguranca", "identificador de s
 SESSION_COOKIE_NAMES = ("JSESSIONID",)
 JURIDICO_COOKIE_DOMAINS = ("juridico.bb.com.br", ".juridico.bb.com.br")
 JURIDICO_COOKIE_PATHS = ("/", "/wfj", "/paj", "/paj/", "/wfj/")
+PROCESSO_AUSENTE_API = "Consulta pendente (API sem numero_processo)"
+CNJ_PATTERN = re.compile(r"(?<!\d)(\d{7}-\d{2}\.\d{4}\.\d\.\d{2}\.\d{4}|\d{20})(?!\d)")
+
+DETALHE_HEADER_SELECTOR = 'h2.left:has-text("Solicitação : Detalhamento")'
+# Trechos que identificam a pagina de erro "Acesso nao autorizado" (advogado nao cadastrado).
+# Comparados sempre em minusculas; basta um deles aparecer para classificar como erro permanente.
+ACESSO_NEGADO_HINTS = (
+    "acesso não autorizado",
+    "acesso nao autorizado",
+    "advogado terceirizado não cadastrado",
+    "advogado terceirizado nao cadastrado",
+    "não cadastrado no portal",
+    "nao cadastrado no portal",
+)
+
+
+class AcessoNaoAutorizadoError(Exception):
+    """Erro permanente: a solicitacao nao pode ser detalhada (advogado nao cadastrado no portal).
+
+    Diferente de um timeout, repetir nao adianta - a solicitacao deve ser marcada e pulada.
+    """
 
 USER_ENV_KEYS = ("BB_USUARIO", "BB_USERNAME", "PORTAL_BB_USUARIO", "PORTAL_BB_USERNAME")
 PASSWORD_ENV_KEYS = ("BB_SENHA", "BB_PASSWORD", "PORTAL_BB_SENHA", "PORTAL_BB_PASSWORD")
@@ -485,16 +506,72 @@ def fazer_login(context) -> Page:
     return fazer_login_direto(context)
 
 
+def normalizar_numero_processo(numero: str) -> str:
+    return re.sub(r"\D", "", numero or "")
+
+
+def extrair_numero_processo_de_texto(texto: str) -> str:
+    match = CNJ_PATTERN.search(texto or "")
+    if not match:
+        return ""
+    return normalizar_numero_processo(match.group(1))
+
+
+def numero_processo_precisa_fallback(numero_processo: str) -> bool:
+    valor = (numero_processo or "").strip().lower()
+    if not valor:
+        return True
+    return (
+        valor == "dado ausente na api"
+        or valor.startswith("consulta pendente")
+        or valor.startswith("processo não encontrado")
+        or valor.startswith("processo nao encontrado")
+        or valor.startswith("erro na api")
+    )
+
+
+def procurar_numero_processo_em_payload(valor) -> str:
+    if isinstance(valor, dict):
+        for chave_preferida in (
+            "textoNumeroInventario",
+            "textoNumeroExternoProcesso",
+            "numeroProcesso",
+            "numeroProcessoFormatado",
+            "textoNumeroProcesso",
+        ):
+            numero = extrair_numero_processo_de_texto(str(valor.get(chave_preferida) or ""))
+            if numero:
+                return numero
+
+        for item in valor.values():
+            numero = procurar_numero_processo_em_payload(item)
+            if numero:
+                return numero
+
+    if isinstance(valor, list):
+        for item in valor:
+            numero = procurar_numero_processo_em_payload(item)
+            if numero:
+                return numero
+
+    if isinstance(valor, str):
+        return extrair_numero_processo_de_texto(valor)
+
+    return ""
+
+
 def extrair_dados_processo_api(api_data: dict) -> tuple[str, str, bool]:
     dados = api_data.get("data", {})
-    numero_processo = (
-        dados.get("textoNumeroInventario")
-        or dados.get("textoNumeroExternoProcesso")
-        or "Dado ausente na API"
-    )
+    numero_processo = procurar_numero_processo_em_payload(dados)
     polo_indicador = dados.get("indicadorPoloBanco", "")
     polo_map = {"A": "Ativo", "P": "Passivo", "N": "Neutro"}
-    return numero_processo, polo_map.get(polo_indicador, "Não definido"), False
+
+    if numero_processo:
+        return numero_processo, polo_map.get(polo_indicador, "Não definido"), False
+
+    chaves_data = ", ".join(sorted(dados.keys())) if isinstance(dados, dict) else type(dados).__name__
+    print(f"    - API respondeu 200, mas sem número de processo. Chaves em data: {chaves_data}")
+    return PROCESSO_AUSENTE_API, "Pendente", True
 
 
 def dados_processo_por_status(status: int, api_data: dict | None = None) -> tuple[str, str, bool]:
@@ -588,12 +665,58 @@ def consultar_dados_processo(page: Page, npj_limpo: str) -> tuple[str, str, bool
     return consultar_dados_processo_no_navegador(page, api_url)
 
 
+def pagina_acesso_negado(page: Page) -> bool:
+    """Detecta a tela de 'Acesso nao autorizado / advogado nao cadastrado'."""
+    try:
+        texto = page.locator("body").inner_text(timeout=800).strip().lower()
+    except Exception:
+        return False
+    if not texto:
+        return False
+    return any(hint in texto for hint in ACESSO_NEGADO_HINTS)
+
+
+def aguardar_pagina_detalhe(page: Page, timeout_ms: int):
+    """Aguarda o cabecalho de detalhamento OU detecta a pagina de acesso negado.
+
+    Faz polling para retornar assim que QUALQUER um dos dois ocorrer, em vez de
+    esperar o timeout inteiro quando a solicitacao cai na pagina de erro permanente.
+    """
+    deadline = time.monotonic() + (timeout_ms / 1000)
+    header = page.locator(DETALHE_HEADER_SELECTOR).first
+    while time.monotonic() < deadline:
+        try:
+            if header.is_visible():
+                return
+        except Exception:
+            pass
+        if pagina_acesso_negado(page):
+            raise AcessoNaoAutorizadoError(
+                "Acesso não autorizado: advogado terceirizado não cadastrado no portal."
+            )
+        time.sleep(0.4)
+
+    # Ultima verificacao antes de desistir (a pagina pode ter mudado no limite do prazo).
+    try:
+        if header.is_visible():
+            return
+    except Exception:
+        pass
+    if pagina_acesso_negado(page):
+        raise AcessoNaoAutorizadoError(
+            "Acesso não autorizado: advogado terceirizado não cadastrado no portal."
+        )
+    raise TimeoutError(
+        f"Cabeçalho de detalhamento não apareceu em {timeout_ms}ms. URL atual: {page.url}"
+    )
+
+
 def coletar_detalhes(page: Page, numero_solicitacao: str) -> dict:
     """Navega para a página de detalhes e extrai todas as informações."""
     match = re.match(r"(\d{4})\/(\d{10})", numero_solicitacao)
     if not match:
         raise ValueError(f"Formato de número inválido: {numero_solicitacao}")
-    
+
     ano, numero = match.groups()
     url_detalhada = f"https://juridico.bb.com.br/wfj/paginas/negocio/tarefa/pesquisar/buscaRapida.seam?buscaRapidaProcesso=busca_solicitacoes&anoSolicitacaoBuscaRapida={ano}&numeroSolicitacaoBuscaRapida={numero}"
 
@@ -602,10 +725,12 @@ def coletar_detalhes(page: Page, numero_solicitacao: str) -> dict:
         timeout=int(os.getenv("RPA_DETALHE_GOTO_TIMEOUT_MS", "90000")),
         wait_until="domcontentloaded",
     )
-    page.wait_for_selector(
-        'h2.left:has-text("Solicitação : Detalhamento")',
-        timeout=int(os.getenv("RPA_DETALHE_SELECTOR_TIMEOUT_MS", "30000")),
+    aguardar_pagina_detalhe(
+        page,
+        int(os.getenv("RPA_DETALHE_SELECTOR_TIMEOUT_MS", "30000")),
     )
+    texto_pagina_detalhe = texto_pagina(page)
+    numero_processo_portal = extrair_numero_processo_de_texto(texto_pagina_detalhe)
     
     # Extração da página principal
     numero_solicitacao_raw = page.locator('span.info_tarefa_label_numero:has-text("Nº da solicitação:") + span.info_tarefa_numero').inner_text()
@@ -637,12 +762,29 @@ def coletar_detalhes(page: Page, numero_solicitacao: str) -> dict:
 
         try:
             numero_processo, polo, _retry_later = consultar_dados_processo(page, npj_limpo)
+            if numero_processo_precisa_fallback(numero_processo):
+                numero_texto_dmi = extrair_numero_processo_de_texto(texto_dmi)
+                numero_fallback = numero_processo_portal or numero_texto_dmi
+                if numero_fallback:
+                    origem = "página de detalhes" if numero_processo_portal else "texto da DMI"
+                    print(f"    - API sem número de processo útil; CNJ recuperado pela {origem}.")
+                    numero_processo = numero_fallback
+                    if polo in ("Pendente", "N/A"):
+                        polo = "Não definido"
             dados_solicitacao["numero_processo"] = numero_processo
             dados_solicitacao["polo"] = polo
         except Exception as exc:
-            print(f"    - Consulta da API falhou; sera tentada novamente no proximo ciclo: {exc}")
-            dados_solicitacao["numero_processo"] = "Consulta pendente"
-            dados_solicitacao["polo"] = "Pendente"
+            numero_texto_dmi = extrair_numero_processo_de_texto(texto_dmi)
+            numero_fallback = numero_processo_portal or numero_texto_dmi
+            if numero_fallback:
+                origem = "página de detalhes" if numero_processo_portal else "texto da DMI"
+                print(f"    - Consulta da API falhou, mas o CNJ foi recuperado pela {origem}: {exc}")
+                dados_solicitacao["numero_processo"] = numero_fallback
+                dados_solicitacao["polo"] = "Não definido"
+            else:
+                print(f"    - Consulta da API falhou; sera tentada novamente no proximo ciclo: {exc}")
+                dados_solicitacao["numero_processo"] = "Consulta pendente"
+                dados_solicitacao["polo"] = "Pendente"
     else:
         dados_solicitacao["numero_processo"] = "NPJ não informado"
         dados_solicitacao["polo"] = "N/A"

--- a/RPA/portal_bb.py
+++ b/RPA/portal_bb.py
@@ -263,9 +263,11 @@ def limpar_cookies_sessao_portal(context):
 
 def abrir_popup_dmi(page: Page):
     botao_detalhar = page.locator("#detalhar\\:j_id106").first
-    botao_detalhar.wait_for(state="visible", timeout=20000)
+    timeout_botao = int(os.getenv("RPA_DMI_BOTAO_TIMEOUT_MS", "30000"))
+    tentativas_popup = int(os.getenv("RPA_DMI_POPUP_TENTATIVAS", "3"))
+    botao_detalhar.wait_for(state="visible", timeout=timeout_botao)
 
-    for tentativa in range(1, 3):
+    for tentativa in range(1, tentativas_popup + 1):
         try:
             with page.context.expect_event("page", timeout=15000) as popup_info:
                 botao_detalhar.evaluate(
@@ -282,8 +284,8 @@ def abrir_popup_dmi(page: Page):
             popup_page.wait_for_load_state("domcontentloaded", timeout=30000)
             return popup_page
         except Exception as click_error:
-            if tentativa == 1:
-                print("    - Popup da DMI não abriu. Tentando novamente...")
+            if tentativa < tentativas_popup:
+                print(f"    - Popup da DMI não abriu na tentativa {tentativa}/{tentativas_popup}. Tentando novamente...")
                 time.sleep(1)
                 continue
             raise click_error
@@ -367,8 +369,15 @@ def coletar_detalhes(page: Page, numero_solicitacao: str) -> dict:
     ano, numero = match.groups()
     url_detalhada = f"https://juridico.bb.com.br/wfj/paginas/negocio/tarefa/pesquisar/buscaRapida.seam?buscaRapidaProcesso=busca_solicitacoes&anoSolicitacaoBuscaRapida={ano}&numeroSolicitacaoBuscaRapida={numero}"
 
-    page.goto(url_detalhada, timeout=60000, wait_until="domcontentloaded")
-    page.wait_for_selector('h2.left:has-text("Solicitação : Detalhamento")', timeout=20000)
+    page.goto(
+        url_detalhada,
+        timeout=int(os.getenv("RPA_DETALHE_GOTO_TIMEOUT_MS", "90000")),
+        wait_until="domcontentloaded",
+    )
+    page.wait_for_selector(
+        'h2.left:has-text("Solicitação : Detalhamento")',
+        timeout=int(os.getenv("RPA_DETALHE_SELECTOR_TIMEOUT_MS", "30000")),
+    )
     
     # Extração da página principal
     numero_solicitacao_raw = page.locator('span.info_tarefa_label_numero:has-text("Nº da solicitação:") + span.info_tarefa_numero').inner_text()

--- a/RPA/requirements.txt
+++ b/RPA/requirements.txt
@@ -16,3 +16,4 @@ typing_extensions==4.15.0
 waitress==3.0.2
 Werkzeug==3.1.3
 requests
+pypdf==6.14.2

--- a/bd/database.py
+++ b/bd/database.py
@@ -205,7 +205,19 @@ def atualizar_detalhes_solicitacao(dados_solicitacao):
 def obter_solicitacoes_pendentes():
     conn = conectar(DB_SOLICITACOES)
     cursor = conn.cursor()
-    cursor.execute("SELECT numero_solicitacao FROM solicitacoes WHERE titulo IS NULL;")
+    cursor.execute("""
+    SELECT numero_solicitacao FROM solicitacoes
+    WHERE status_sistema = 'Aberto'
+      AND (
+           titulo IS NULL
+        OR numero_processo IS NULL
+        OR numero_processo = ''
+        OR numero_processo LIKE 'Consulta pendente%'
+        OR numero_processo LIKE 'Erro na API%'
+        OR polo = 'Erro na API'
+        OR polo = 'Pendente'
+      );
+    """)
     pendentes = [row['numero_solicitacao'] for row in cursor.fetchall()]
     conn.close()
     return pendentes

--- a/bd/database.py
+++ b/bd/database.py
@@ -212,6 +212,7 @@ def obter_solicitacoes_pendentes():
            titulo IS NULL
         OR numero_processo IS NULL
         OR numero_processo = ''
+        OR numero_processo = 'Dado ausente na API'
         OR numero_processo LIKE 'Consulta pendente%'
         OR numero_processo LIKE 'Erro na API%'
         OR polo = 'Erro na API'

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ typing_extensions==4.15.0
 waitress==3.0.2
 Werkzeug==3.1.3
 requests
+pypdf==6.14.2

--- a/run_robos.py
+++ b/run_robos.py
@@ -4,14 +4,17 @@ import subprocess
 import sys
 from pathlib import Path
 from datetime import datetime
+from RPA.observability import install_print_logger, log_event
 
 PROJECT_DIR = Path(__file__).resolve().parent
 PYTHON_EXE = sys.executable
+logger = install_print_logger("agendador-mestre")
 
 
 def executar_robo_1():
     """Executa o Robô 1: Coleta de Números de Solicitação."""
     print(f"\n[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] --- INICIANDO ROBO 1: Coleta de Numeros ---")
+    log_event(logger, "Iniciando robo 1.", robot="robo-coleta-numeros", status="started")
     try:
         # Chama o script do Robô 1
         subprocess.run(
@@ -20,14 +23,17 @@ def executar_robo_1():
             cwd=PROJECT_DIR
         )
         print(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] --- ROBO 1 FINALIZADO COM SUCESSO ---")
+        log_event(logger, "Robo 1 finalizado com sucesso.", robot="robo-coleta-numeros", status="success")
         return True # Retorna sucesso
     except Exception as e:
         print(f"\n!!!!!! ERRO CRITICO NA EXECUCAO DO ROBO 1: {e} !!!!!!")
+        log_event(logger, f"Erro critico na execucao do robo 1: {e}", robot="robo-coleta-numeros", status="error")
         return False # Retorna falha
 
 def executar_robo_2():
     """Executa o Robô 2: Coleta de Detalhes das Solicitações."""
     print(f"\n[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] --- INICIANDO ROBO 2: Coleta de Detalhes ---")
+    log_event(logger, "Iniciando robo 2.", robot="robo-detalhes", status="started")
     try:
         # Chama o script do Robô 2
         subprocess.run(
@@ -36,8 +42,10 @@ def executar_robo_2():
             cwd=PROJECT_DIR
         )
         print(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] --- ROBO 2 FINALIZADO COM SUCESSO ---")
+        log_event(logger, "Robo 2 finalizado com sucesso.", robot="robo-detalhes", status="success")
     except Exception as e:
         print(f"\n!!!!!! ERRO CRITICO NA EXECUCAO DO ROBO 2: {e} !!!!!!")
+        log_event(logger, f"Erro critico na execucao do robo 2: {e}", robot="robo-detalhes", status="error")
 
 def ciclo_completo_de_automacao():
     """

--- a/scheduler_coleta_numeros.py
+++ b/scheduler_coleta_numeros.py
@@ -4,22 +4,27 @@ import subprocess
 import sys
 from pathlib import Path
 from datetime import datetime
+from RPA.observability import install_print_logger, log_event
 
 PROJECT_DIR = Path(__file__).resolve().parent
 PYTHON_EXE = sys.executable
+logger = install_print_logger("scheduler-coleta-numeros")
 
 
 def executar_robo_coleta_numeros():
     """Executa o robô que coleta os números de solicitação."""
     print(f"\n[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] --- INICIANDO ROBO 1: Coleta de Numeros ---")
+    log_event(logger, "Iniciando robo de coleta de numeros.", robot="robo-coleta-numeros", status="started")
     try:
         subprocess.run(
             [PYTHON_EXE, str(PROJECT_DIR / "RPA" / "coletaDadosNumeroSolicitacoes.py")],
             check=True,
             cwd=PROJECT_DIR
         )
+        log_event(logger, "Robo de coleta de numeros finalizado com sucesso.", robot="robo-coleta-numeros", status="success")
     except Exception as e:
         print(f"\n!!!!!! ERRO CRITICO NA EXECUCAO DO ROBO 1: {e} !!!!!!")
+        log_event(logger, f"Erro critico na execucao do robo de coleta de numeros: {e}", robot="robo-coleta-numeros", status="error")
     
     proxima = schedule.jobs[0].next_run.strftime('%H:%M:%S') if schedule.jobs else 'N/A'
     print(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] --- ROBO 1 FINALIZADO. Proxima execucao as {proxima} ---")

--- a/scheduler_detalhes.py
+++ b/scheduler_detalhes.py
@@ -4,22 +4,27 @@ import subprocess
 import sys
 from pathlib import Path
 from datetime import datetime
+from RPA.observability import install_print_logger, log_event
 
 PROJECT_DIR = Path(__file__).resolve().parent
 PYTHON_EXE = sys.executable
+logger = install_print_logger("scheduler-detalhes")
 
 
 def executar_robo_detalhes():
     """Executa o robô que busca os detalhes das solicitações."""
     print(f"\n[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] --- INICIANDO ROBO 2: Detalhamento de Solicitacoes ---")
+    log_event(logger, "Iniciando robo de detalhes.", robot="robo-detalhes", status="started")
     try:
         subprocess.run(
             [PYTHON_EXE, str(PROJECT_DIR / "RPA" / "main.py")],
             check=True,
             cwd=PROJECT_DIR
         )
+        log_event(logger, "Robo de detalhes finalizado com sucesso.", robot="robo-detalhes", status="success")
     except Exception as e:
         print(f"\n!!!!!! ERRO CRITICO NA EXECUCAO DO ROBO 2: {e} !!!!!!")
+        log_event(logger, f"Erro critico na execucao do robo de detalhes: {e}", robot="robo-detalhes", status="error")
 
     proxima = schedule.jobs[0].next_run.strftime('%H:%M:%S') if schedule.jobs else 'N/A'
     print(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] --- ROBO 2 FINALIZADO. Proxima execucao as {proxima} ---")

--- a/server.py
+++ b/server.py
@@ -15,6 +15,28 @@ import requests
 app = Flask(__name__)
 app.secret_key = 'sua_chave_secreta_super_segura_pode_ser_qualquer_coisa' 
 
+
+def carregar_env_local():
+    """Carrega .env local sem depender de python-dotenv."""
+    env_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
+    if not os.path.exists(env_path):
+        return
+    with open(env_path, encoding="utf-8") as env_file:
+        for raw_line in env_file:
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            env_key = key.strip()
+            env_value = value.strip().strip('"').strip("'")
+            if env_key.startswith("TWOTASK_"):
+                os.environ[env_key] = env_value
+            else:
+                os.environ.setdefault(env_key, env_value)
+
+
+carregar_env_local()
+
 # --- Configuração do Flask-Login ---
 login_manager = LoginManager()
 login_manager.init_app(app)
@@ -450,10 +472,14 @@ def api_criar_tarefa():
     }
 
     # 5. Envia o POST para a API externa
-    API_URL = "http://192.168.0.66:8000/api/v1/tasks/batch-create"
+    API_URL = os.getenv("TWOTASK_BATCH_CREATE_URL", "https://flow.mdradvocacia.com/api/v1/tasks/batch-create")
+    api_key = (os.getenv("TWOTASK_BATCH_API_KEY") or "").strip()
+    if not api_key:
+        return jsonify({'status': 'erro', 'mensagem': 'TWOTASK_BATCH_API_KEY não configurada no .env do OneRequest.'}), 500
+    headers = {"X-Batch-Api-Key": api_key}
     
     try:
-        response = requests.post(API_URL, json=output_data, timeout=10)
+        response = requests.post(API_URL, json=output_data, headers=headers, timeout=10)
         
         # --- CORREÇÃO: ACEITAR 202 COMO SUCESSO ---
         if response.status_code in [200, 201, 202]:

--- a/templates/index.html
+++ b/templates/index.html
@@ -120,7 +120,7 @@
                     
                     <td>{{ item['numero_solicitacao'] }}</td>
                     
-                    <td {% if 'não' in item['numero_processo']|lower or 'erro' in item['numero_processo']|lower %}class="status-info"{% endif %}>
+                    <td {% if 'não' in item['numero_processo']|lower or 'erro' in item['numero_processo']|lower or 'pendente' in item['numero_processo']|lower %}class="status-info"{% endif %}>
                         {{ item['numero_processo'] }}
                     </td>
 


### PR DESCRIPTION
Segue a descrição pronta para colar no Pull Request:

---

## Correção e otimização dos robôs de coleta (OneRequest)

Corrige os dois robôs de RPA que estavam travando/inconsistentes na coleta de solicitações do Portal Jurídico BB.

###  Robô de Detalhes (`RPA/main.py`, `RPA/portal_bb.py`)

**Problema:** ao detalhar uma solicitação que cai na página *"Acesso não autorizado. Advogado terceirizado não cadastrado no portal"*, o cabeçalho `Solicitação : Detalhamento` nunca carrega. O robô esperava os 30s inteiros do `wait_for_selector`, falhava e repetia 3× com 10s de espera (~110s perdidos por item). Como o erro é permanente, a solicitação seguia "pendente" e travava a fila a cada ciclo.

**Correção:**
- Nova exceção `AcessoNaoAutorizadoError` para distinguir erro permanente de timeout.
- `aguardar_pagina_detalhe()` faz *polling em corrida*: retorna assim que o cabeçalho aparece **ou** assim que a página de erro é detectada (~0,4s, em vez de 30s).
- O erro permanente passa a ser tratado **sem retentativas**: a solicitação é marcada no banco (`numero_processo = "Acesso não autorizado"`, `polo = "N/A"`), sai da fila de pendentes e fica visível no painel para acionamento da Ajure.

**Validação:** execução real processou **129/129** solicitações de ponta a ponta, sem travamentos. A solicitação que antes travava (`2026/0000288134`) foi processada com sucesso na 1ª tentativa.

###  Robô de Coleta de Números (`RPA/coletaDadosNumeroSolicitacoes.py`)

**Problema:** a coleta navegava página por página numa dataTable JSF/Seam (mudar paginação para 50, detectar "próxima página", iterar ~28 páginas) — frágil e ponto de falha recorrente (timeout no botão "Pesquisar").

**Correção:** substituída a paginação pelo botão **"Imprimir Relatório"** do portal, que gera um PDF único (`Tarefa.pdf`) com todas as solicitações pendentes:
- Pesquisar → clicar "Imprimir Relatório" → capturar o download → extrair os números com `pypdf`.
- Tratamento do formato do PDF (os números quebram em 2 linhas pela coluna estreita).
- **Validação automática** da contagem extraída contra o contador do portal (falha se vier incompleto).
- Retry mais resiliente: repete também em falhas transitórias (timeout no Pesquisar/download) renavegando.

**Validação:** execução real baixou o relatório, extraiu **265/265** números (conferidos com o contador do portal) e sincronizou o banco corretamente.

###  Dependências
- Adicionado `pypdf==6.14.2` em `requirements.txt` e `RPA/requirements.txt`.
- **Ação no deploy:** rodar `pip install pypdf==6.14.2` no venv de produção antes de subir.

### Arquivos alterados
- `RPA/main.py`
- `RPA/portal_bb.py`
- `RPA/coletaDadosNumeroSolicitacoes.py`
- `requirements.txt`
- `RPA/requirements.txt`

---
